### PR TITLE
Adds json schema validation and separates paths from objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.1 (2015-03-06)
+Features:
+    * Adds validation againts json schema
+
+## 0.1.0 (2015-03-04)
+
+Initial Release

--- a/fabutils/env.py
+++ b/fabutils/env.py
@@ -3,66 +3,78 @@ import json
 
 from fabric.api import env
 
+from jsonschema import validate
+
 from .exceptions import EnvironmentNotDefinedError
-from .tasks import ulocal
 
 
-def set_env(env_name, json_path):
+def set_env_from_json_file(json_path, property_name=None, schema_path=None):
     """
-    Creates a dynamic environment based on the contents of the given
-    json_path. Note that a this task relies on a "vagrant" environment defined
-    on your environments json file to populate the task's env with the proper
-    Vagrant's identity file.
-
-    This task must be used to create your own envionment task in your fabfile,
-    for example:
-
-        # /path/to/my/environments/file.json
-        {
-            "vagrant": {
-                "some_property": "some_value",
-                "another_property": "another_value"
-            },
-            "staging": {
-                ...
-            }
-        }
+    Creates a dynamic environment given a json_path to an environment file,
+    using property_name as the initial node to start reading, validating
+    against a json schema file if given any
 
 
-        # fabfile.py
-        from fabric.api import task
-        from fabutils.env import set_env
+    @task
+    def environment(env_name):
+        set_env('/path/to/my/environments/file.json', property_name)
 
-
-        @task
-        def environment(env_name):
-            set_env(env_name, '/path/to/my/environments/file.json')
-
-        @task
-        def some_task():
-            ...
-
+    @task
+    def some_task():
+        ...
 
     And call it as follows:
 
         fab envinronment:vagrant some_task
     """
+    if schema_path:  # if schema_path is provided
+        with open(schema_path, 'r') as schema_file:
+            json_schema = json.load(schema_file)
+    else:
+        json_schema = None
+
     with open(json_path, 'r') as data:
-        try:
-            environment = json.load(data)[env_name]
 
-        except KeyError:
-            raise EnvironmentNotDefinedError(
-                "The environment '{0}' is not defined in file '{1}'".format(
-                    env_name, json_path
+        if property_name:
+            try:
+                set_env_from_json(json.load(data)[property_name], json_schema)
+
+            except KeyError:
+                raise EnvironmentNotDefinedError(
+                    "The property_name '{0}' is not defined in file '{1}'".format(
+                        property_name, json_path
+                    )
                 )
-            )
+        else:
+            set_env_from_json(json.load(data), json_schema)
 
-    # Update the env with the Vagrant's identity file if the given env_name is
-    # "vagrant" and no key_filename property is defined in the current env.
-    if env_name == 'vagrant' and 'key_filename' not in environment:
-        result = ulocal('vagrant ssh-config | grep IdentityFile', capture=True)
-        env.key_filename = result.split()[1].replace('"', '')
+
+def set_env_from_json(json_object, json_schema=None):
+    """
+    Creates a dynamic environment based on the contents of the given
+    json_object and validates againts a json_schema object if given any.
+
+    If 'command_prefixes' is available it adds it to the environment prepending
+    'source' to the given paths.
+
+
+    # fabfile.py
+    from fabric.api import task
+    from fabutils.env import set_env_from_json
+
+    @task
+    def some_task():
+        with open('/path/to/json', 'r') as json_object, \
+                open('/path/to/schema') as json_schema:
+
+        set_env_from_json(json_object, json_schema)
+
+
+    """
+    if json_schema:
+        validate(json_object, json_schema)
+
+    environment = json_object
 
     # Prepend the command "source" to each one of the commands defined in the
     # command_prefixes property of the json file.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     url='https://github.com/vinco/fabutils',
     license='Apache License (2.0)',
     install_requires=[
-        'fabric >= 1.10'
+        'fabric >= 1.10',
+        'jsonschema >= 2.4'
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
# Tareas relacionadas

[Configuración con jsons de proyecto](http://manoderecha.net/md/index.php/task/90898)
# Descripción del problema

Se requiere cargar datos en la variable `env` de fabric a partir de archivos de tipo JSON que permitan ser validados por medio de un [json_schema](http://json-schema.org/documentation.html)
# Descripción de la solución

Se modifica la función `set_env_from_json` para que reciba objetos y no archivos, valida y carga los datos

Se añade la función `set_env_from_json_file` para que reciba los path de los archivos además de una propiedad del json desde la cual se cargarán los datos
# Cambios en dependencias

Se añade una dependencia a `jsonschema >= 2.4`
