### PR TITLE
Fix command_prefixes when loading environment from multiple files

### DIFF
--- a/fabutils/env.py
+++ b/fabutils/env.py
@@ -78,8 +78,8 @@ def set_env_from_json(json_object, json_schema=None):
 
     # Prepend the command "source" to each one of the commands defined in the
     # command_prefixes property of the json file.
-    prefixes = environment.get('command_prefixes', [])
+    prefixes = environment.pop('command_prefixes', [])
     sourced_prefixes = map(lambda p: 'source %s' % p, prefixes)
-    environment.update(command_prefixes=sourced_prefixes)
 
     env.update(environment)
+    env.command_prefixes += sourced_prefixes


### PR DESCRIPTION
# Tareas relacionadas
- [#92649 Corregir error en fabutils al cargar el entorno desde múltiples archivos](http://manoderecha.net/md/index.php/task/92649)
## Descripción del problema

Al establecer el entorno desde múltiples archivos, sólo se cargan los `command_prefixes` del último archivo si es que los tiene o se dejan vacíos.
## Descripción de la solución

Se cambió el método `fabutils.env.set_env_from_json` para agregar los command_prefixes en lugar de reemplazarlos.
## Plan de pruebas

Se realizó el ejemplo tal como en #2 y se verificó que ya se muestre el source de los command_prefixes en la salida de fabric.
